### PR TITLE
Removed casting login code to int.

### DIFF
--- a/src/Auth/SecurityToken.php
+++ b/src/Auth/SecurityToken.php
@@ -117,7 +117,7 @@ class SecurityToken extends AbstractAuth
      */
     public function setchallengeResponse($challengeResponse)
     {
-        $this->_challengeResponse = (int)$challengeResponse;
+        $this->_challengeResponse = $challengeResponse;
     }
 
     /**


### PR DESCRIPTION
When the code is casted to an int it looses leading zeros. So the code "01234567" becomes "1234567" and Swedbank treats that code as invalid. So without this patch its impossible to login using a code thats starts with a zero.