### PR TITLE
Update MobileBankID.php

### DIFF
--- a/src/Auth/MobileBankID.php
+++ b/src/Auth/MobileBankID.php
@@ -53,6 +53,7 @@ class MobileBankID extends AbstractAuth
             [
                 'useEasyLogin'        => false,
                 'generateEasyLoginId' => false,
+                'bankIdOnSameDevice'  => false,
                 'userId'              => $this->_username,
             ]);
 


### PR DESCRIPTION
Authentication stopped working with the following exception:
Uncaught SwedbankJson\Exception\ApiException: general (1): BankIdOnSameDeviceAttributeNotProvided - Det gick inte att logga in. Din klient skickade inte in valet om BankID finns installerad på detta enhet eller ej.; fields (1): Valet av enhet för BankID angavs ej.

From the name of the error it was quite easy to guess that the attribute needed was "bankIdOnSameDevice".